### PR TITLE
fix: mdc dialog styles not being applied to secret generator module

### DIFF
--- a/console/src/app/modules/policies/secret-generator/secret-generator.module.ts
+++ b/console/src/app/modules/policies/secret-generator/secret-generator.module.ts
@@ -8,7 +8,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { TranslateModule } from '@ngx-translate/core';
 import { HasRolePipeModule } from 'src/app/pipes/has-role-pipe/has-role-pipe.module';
-
+import { MatDialogModule } from '@angular/material/dialog';
 import { CardModule } from '../../card/card.module';
 import { FormFieldModule } from '../../form-field/form-field.module';
 import { InputModule } from '../../input/input.module';
@@ -31,6 +31,7 @@ import { SecretGeneratorComponent } from './secret-generator.component';
     MatProgressSpinnerModule,
     MatSelectModule,
     TranslateModule,
+    MatDialogModule,
   ],
   exports: [SecretGeneratorComponent, DialogAddSecretGeneratorComponent],
 })


### PR DESCRIPTION
# Which Problems Are Solved

- Styles from the material design component dialog are not being applied (no padding, wrong theme colors for titles...)

# How the Problems Are Solved

- The MatDialogModule has been added to secret-generator.module.ts so the styles are applied 

Here's a video showing the fix in action:

https://github.com/doncicuto/zitadel/assets/30386061/32567e58-b7d6-48da-8369-b48e23828a5c

# Additional Context

- Closes #8085
